### PR TITLE
feat: move `apt update`, use wine-stable and winecfg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt update \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENV WINEARCH=win64
+ENV WINEARCH=win64 \
+    WINEDEBUG=-all
 
 RUN winecfg
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
+# Build on Apple Silicon chips: docker buildx build --platform=linux/x86_64
 FROM ubuntu:latest
 
-RUN dpkg --add-architecture i386 && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y wine-development && \
-    apt-get clean  && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt update \
+    && dpkg --add-architecture i386 \
+    && DEBIAN_FRONTEND=noninteractive apt install -y wine-stable \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV WINEARCH=win64 \
-    WINEDEBUG=-all
-	
-RUN wineboot --init
+ENV WINEARCH=win64
+
+RUN winecfg
 
 VOLUME /opt/server
 WORKDIR /opt/server


### PR DESCRIPTION
Hello 👋🏻 

I would like to suggest some modifications to our Dockerfile so that it can be updated and aligned with the latest standards:
- `apt update` at the beginning of the **RUN** directive to update the latest package registries (required for the next step).
- Use **wine-stable** instead of the legacy development package.
- Use **winecfg** instead of the (legacy as well?) wineboot.

Thanks for your work, and wish you a nice day.